### PR TITLE
Dev: Adds EGLO as gsf model

### DIFF
--- a/Models/include/gambit/Models/models/GSFModels.hpp
+++ b/Models/include/gambit/Models/models/GSFModels.hpp
@@ -21,7 +21,17 @@
 
 #define MODEL GSFModel20
   START_MODEL
-  DEFINEPARS(gsf_p1,gsf_p2,gsf_p3,gsf_p4,gsf_p5,gsf_p6,gsf_p7,gsf_p8,gsf_p9,gsf_p10,gsf_p11,gsf_p12,gsf_p13,gsf_p14,gsf_p15,gsf_p16,gsf_p17,gsf_p18,gsf_p19,gsf_p20)
+  DEFINEPARS(gsf_p1,gsf_p2,gsf_p3,gsf_p4,gsf_p5,gsf_p6,gsf_p7,gsf_p8,gsf_p9,gsf_p10,gsf_p11,gsf_p12,gsf_p13,gsf_p14,gsf_p15,gsf_p16,gsf_p17,gsf_p18,gsf_p19,gsf_T)
+#undef MODEL
+
+#define MODEL GSF_GLOModel20
+  START_MODEL
+  DEFINEPARS(gsf_p1,gsf_p2,gsf_p3,gsf_p4,gsf_p5,gsf_p6,gsf_p7,gsf_p8,gsf_p9,gsf_p10,gsf_p11,gsf_p12,gsf_p13,gsf_p14,gsf_p15,gsf_p16,gsf_p17,gsf_p18,gsf_p19,gsf_T)
+#undef MODEL
+
+#define MODEL GSF_EGLOModel20
+  START_MODEL
+  DEFINEPARS(gsf_p1,gsf_p2,gsf_p3,gsf_p4,gsf_p5,gsf_p6,gsf_p7,gsf_p8,gsf_p9,gsf_p10,gsf_p11,gsf_p12,gsf_p13,gsf_p14,gsf_p15,gsf_p16,gsf_p17,gsf_p18,gsf_p19,gsf_T,gsf_epsilon_0,gsf_k)
 #undef MODEL
 
 #endif /* defined(__gsfmodels_hpp__) */

--- a/NuclearBit/include/gambit/NuclearBit/NuclearBit_rollcall.hpp
+++ b/NuclearBit/include/gambit/NuclearBit/NuclearBit_rollcall.hpp
@@ -25,7 +25,8 @@ START_MODULE
   START_CAPABILITY
     #define FUNCTION getGledeliResults
     START_FUNCTION(map_str_dbl)
-    ALLOW_MODELS(GSFModel20, NLDModelCT_and_discretes, NLDModelBSFG_and_discretes)
+    ALLOW_MODELS(GSFModel20, GSF_GLOModel20, GSF_EGLOModel20,
+                 NLDModelCT_and_discretes, NLDModelBSFG_and_discretes)
     BACKEND_REQ(gledeliBE_set_model_pars, (), void, (pybind11::dict&))
     BACKEND_REQ(gledeliBE_set_model_names, (), void, (pybind11::list&))
     BACKEND_REQ(gledeliBE_run, (), pybind11::dict, (pybind11::dict&))

--- a/yaml_files/NuclearBit_demo.yaml
+++ b/yaml_files/NuclearBit_demo.yaml
@@ -7,7 +7,7 @@
 
 Parameters:
 
-  GSFModel20:
+  GSF_GLOModel20:
     gsf_p1:
       prior_type: flat
       range: [11, 13]
@@ -61,7 +61,7 @@ Parameters:
       fixed_value: 0
     gsf_p19:
       fixed_value: 0
-    gsf_p20:
+    gsf_T:
       prior_type: log
       range: [0.4, 0.8]
 


### PR DESCRIPTION
The default model is still GLO
- GSFModel20 = GSF_GLOModel20 [for backwards compatibility; might remove it later]
- GSF_EGLOModel20 implements EGLO model
  (which for gsf_k=1 is again the same as GLO, but otherwise not)